### PR TITLE
Add base Convex schema and seed data for users and sessions

### DIFF
--- a/convex/seed.ts
+++ b/convex/seed.ts
@@ -1,0 +1,54 @@
+// convex/seed.ts
+
+/**
+ * Seed script used to populate the database
+ * with initial controlled values.
+ *
+ * These tables represent enumerated concepts
+ * but are implemented as lookup tables so the
+ * system can evolve without schema migrations.
+ */
+
+import { mutation } from "./_generated/server";
+
+export const seedDatabase = mutation(async ({ db }) => {
+
+  /**
+   * ROLES
+   *
+   * Platform roles for users.
+   */
+  await db.insert("roles", { name: "interviewer" });
+  await db.insert("roles", { name: "interviewee" });
+  await db.insert("roles", { name: "both" });
+
+
+
+  /**
+   * INTERVIEW TYPES
+   *
+   * Common mock interview formats used across platforms.
+   */
+  await db.insert("interviewTypes", { name: "technical" });
+  await db.insert("interviewTypes", { name: "behavioral" });
+  await db.insert("interviewTypes", { name: "system design" });
+  await db.insert("interviewTypes", { name: "product sense" });
+  await db.insert("interviewTypes", { name: "case study" });
+  await db.insert("interviewTypes", { name: "resume review" });
+
+
+
+  /**
+   * TOPICS
+   *
+   * Interview preparation domains.
+   */
+  await db.insert("topics", { name: "data structures & algorithms" });
+  await db.insert("topics", { name: "system design" });
+  await db.insert("topics", { name: "backend engineering" });
+  await db.insert("topics", { name: "frontend engineering" });
+  await db.insert("topics", { name: "distributed systems" });
+  await db.insert("topics", { name: "product management" });
+  await db.insert("topics", { name: "machine learning" });
+
+});

--- a/convex/sessions.ts
+++ b/convex/sessions.ts
@@ -1,20 +1,177 @@
+// convex/schema.ts
+
+/**
+ * Base database schema for the mock interview platform.
+ *
+ * This schema is intentionally normalized so that:
+ * - roles, topics, and interview types are controlled vocabularies
+ * - users can select multiple roles and topics
+ * - sessions connect two users together
+ *
+ * The schema is designed to support:
+ * - authentication
+ * - onboarding (roles, topics)
+ * - scheduling mock interviews
+ * - querying upcoming sessions
+ * - matching users by topic
+ */
+
+import { defineSchema, defineTable } from "convex/server";
 import { v } from "convex/values";
-import { query, mutation } from "./_generated/server";
 
-export const list = query({
-  handler: async (ctx) => {
-    return await ctx.db.query("sessions").collect();
-  },
-});
+export default defineSchema({
 
-export const create = mutation({
-  args: {
-    intervieweeId: v.id("users"),
+  /**
+   * USERS
+   *
+   * Stores authentication and profile information.
+   *
+   * Important notes:
+   * - email must be unique (login lookup)
+   * - passwordHash is stored instead of plaintext password
+   * - timezone is needed to properly render scheduled interviews
+   */
+  users: defineTable({
+    fullName: v.string(),
+    email: v.string(),
+    passwordHash: v.string(),
+    timezone: v.string(),
+
+    createdAt: v.number(), // unix timestamp
+  })
+    // login queries must be fast
+    .index("by_email", ["email"]),
+
+
+  /**
+   * ROLES
+   *
+   * Controlled vocabulary table.
+   *
+   * Users can be:
+   * - interviewer
+   * - interviewee
+   * - both
+   *
+   * Stored as a table rather than an enum so the system
+   * can expand in the future without changing the schema.
+   */
+  roles: defineTable({
+    name: v.string(),
+  })
+    .index("by_name", ["name"]),
+
+
+  /**
+   * USER ROLES
+   *
+   * Join table linking users to roles.
+   *
+   * Many-to-many relationship:
+   * A user may have multiple roles.
+   */
+  userRoles: defineTable({
+    userId: v.id("users"),
+    roleId: v.id("roles"),
+  })
+    .index("by_user", ["userId"]),
+
+
+
+
+  /**
+   * TOPICS
+   *
+   * Topics represent areas users want to practice interviews in.
+   *
+   * Examples:
+   * - system design
+   * - data structures & algorithms
+   * - product management
+   */
+  topics: defineTable({
+    name: v.string(),
+  })
+    .index("by_name", ["name"]),
+
+
+  /**
+   * USER TOPICS
+   *
+   * Many-to-many relationship between users and topics.
+   *
+   * Allows users to select multiple practice areas.
+   */
+  userTopics: defineTable({
+    userId: v.id("users"),
+    topicId: v.id("topics"),
+  })
+    .index("by_user", ["userId"])
+    .index("by_topic", ["topicId"]),
+
+
+
+  /**
+   * INTERVIEW TYPES
+   *
+   * Defines categories of interviews on the platform.
+   *
+   * Typical industry categories:
+   * - technical
+   * - behavioral
+   * - system design
+   * - product sense
+   * - case study
+   */
+  interviewTypes: defineTable({
+    name: v.string(),
+  })
+    .index("by_name", ["name"]),
+
+
+
+  /**
+   * SESSIONS
+   *
+   * Core interaction table connecting two users.
+   *
+   * Represents a scheduled mock interview.
+   *
+   * Relationships:
+   * - interviewerId → users
+   * - intervieweeId → users
+   * - topicId → topics
+   * - interviewTypeId → interviewTypes
+   *
+   * status is stored as string because states may evolve:
+   * - pending
+   * - scheduled
+   * - completed
+   * - cancelled
+   *
+   * scheduledAt uses a UNIX timestamp to avoid timezone bugs.
+   */
+  sessions: defineTable({
+
     interviewerId: v.id("users"),
+    intervieweeId: v.id("users"),
+
+    topicId: v.id("topics"),
+    interviewTypeId: v.id("interviewTypes"),
+
     status: v.string(),
-    scheduledAt: v.string(),
-  },
-  handler: async (ctx, args) => {
-    return await ctx.db.insert("sessions", args);
-  },
+
+    scheduledAt: v.number(),
+
+    createdAt: v.number(),
+  })
+
+    // Used when showing upcoming interviews for interviewer
+    .index("by_interviewer", ["interviewerId"])
+
+    // Used when showing upcoming interviews for interviewee
+    .index("by_interviewee", ["intervieweeId"])
+
+    // Used when filtering sessions by time
+    .index("by_schedule_time", ["scheduledAt"]),
 });


### PR DESCRIPTION
## Overview

Adds the initial Convex database schema for the mock interview platform.
This provides the foundation for authentication, onboarding, topic selection, and interview scheduling.

## Tables

* **users** – user profile and auth data (`fullName`, `email`, `passwordHash`, `timezone`, `createdAt`). Indexed by `email` for login.
* **roles** – allowed user roles (`interviewer`, `interviewee`, `both`).
* **userRoles** – join table linking users to roles.
* **topics** – predefined interview topics (e.g., DSA, system design, product management).
* **userTopics** – join table linking users to selected topics.
* **interviewTypes** – interview formats (technical, behavioral, system design, etc.).
* **sessions** – scheduled mock interviews between two users with topic, type, status, and time.

Indexes support common queries (login lookup, user sessions, scheduling).

## Seed Data

`seed.ts` populates lookup tables:

* roles
* topics
* interviewTypes

## Notes

The schema uses normalized lookup tables, many-to-many join tables, and timestamp-based scheduling to support future features like authentication, onboarding, matching, and session scheduling.
