### PR TITLE
backend for dashboard auth

### DIFF
--- a/client/app/(app)/dashboard/page.tsx
+++ b/client/app/(app)/dashboard/page.tsx
@@ -24,19 +24,23 @@ type ApiSession = {
 export default function DashboardPage() {
   const { user } = useAuth();
   const [sessions, setSessions] = useState<ApiSession[]>([]);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     fetch(`${BASE}/sessions/`, { credentials: "include" })
       .then((r) => (r.ok ? r.json() : []))
       .then(setSessions)
-      .catch(() => setSessions([]));
+      .catch(() => setSessions([]))
+      .finally(() => setLoading(false));
   }, []);
 
   return (
     <div>
       <h1 className="text-[28px] font-semibold tracking-tight mb-1">Home</h1>
       <p className="text-[15px] text-muted-foreground mb-10">
-        {sessions.length > 0
+        {loading
+          ? "Loading…"
+          : sessions.length > 0
           ? `${sessions.length} upcoming session${sessions.length > 1 ? "s" : ""}`
           : "No upcoming sessions"}
       </p>

--- a/client/app/(app)/dashboard/page.tsx
+++ b/client/app/(app)/dashboard/page.tsx
@@ -1,39 +1,58 @@
 "use client";
 
 import { Avatar } from "@/components/ui/avatar";
-import { currentUser, sessions, users } from "@/lib/mock-data";
+import { useAuth } from "@/lib/context/auth";
 import { formatDate, formatTime, interviewTypeLabels } from "@/lib/utils";
 import { ArrowRight, Video } from "lucide-react";
 import Link from "next/link";
+import { useEffect, useState } from "react";
+
+const BASE = process.env.NEXT_PUBLIC_API_URL!;
+
+type ApiSession = {
+  id: string;
+  status: string;
+  scheduled_at: string;
+  meeting_link: string | null;
+  interview_type: string | null;
+  interviewer_id: string;
+  interviewer_name: string;
+  interviewee_id: string;
+  interviewee_name: string;
+};
 
 export default function DashboardPage() {
-  const upcomingSessions = sessions.filter((s) => s.status === "confirmed");
-  const interviewerCount = users.filter(
-    (u) => u.id !== currentUser.id && (u.role === "interviewer" || u.role === "both")
-  ).length;
+  const { user } = useAuth();
+  const [sessions, setSessions] = useState<ApiSession[]>([]);
+
+  useEffect(() => {
+    fetch(`${BASE}/sessions/`, { credentials: "include" })
+      .then((r) => (r.ok ? r.json() : []))
+      .then(setSessions)
+      .catch(() => setSessions([]));
+  }, []);
 
   return (
     <div>
       <h1 className="text-[28px] font-semibold tracking-tight mb-1">Home</h1>
       <p className="text-[15px] text-muted-foreground mb-10">
-        {upcomingSessions.length > 0
-          ? `${upcomingSessions.length} upcoming session${upcomingSessions.length > 1 ? "s" : ""}`
+        {sessions.length > 0
+          ? `${sessions.length} upcoming session${sessions.length > 1 ? "s" : ""}`
           : "No upcoming sessions"}
       </p>
 
       {/* Upcoming sessions */}
-      {upcomingSessions.length > 0 && (
+      {sessions.length > 0 && (
         <section className="mb-12">
           <h2 className="text-[13px] font-medium text-muted-foreground uppercase tracking-wider mb-4">
             Upcoming
           </h2>
           <div className="flex flex-col gap-2">
-            {upcomingSessions.map((session) => {
-              const isInterviewer = session.interviewer.id === currentUser.id;
-              const partner = isInterviewer
-                ? session.interviewee
-                : session.interviewer;
-              const scheduled = new Date(session.scheduledAt);
+            {sessions.map((session) => {
+              const isInterviewer = session.interviewer_id === user?.id;
+              const partnerName = isInterviewer
+                ? session.interviewee_name
+                : session.interviewer_name;
 
               return (
                 <Link
@@ -41,29 +60,34 @@ export default function DashboardPage() {
                   href={`/sessions/${session.id}`}
                   className="flex items-center gap-4 p-4 -mx-4 rounded-xl hover:bg-muted/50 transition-colors"
                 >
-                  <Avatar name={partner.name} size="md" />
+                  <Avatar name={partnerName} size="md" />
                   <div className="flex-1 min-w-0">
-                    <p className="text-[14px] font-medium">{partner.name}</p>
+                    <p className="text-[14px] font-medium">{partnerName}</p>
                     <p className="text-[13px] text-muted-foreground">
-                      {interviewTypeLabels[session.interviewType]} &middot;{" "}
-                      {formatDate(session.scheduledAt)} at{" "}
+                      {session.interview_type
+                        ? interviewTypeLabels[session.interview_type] ?? session.interview_type
+                        : "Interview"}{" "}
+                      &middot; {formatDate(session.scheduled_at)} at{" "}
                       {formatTime(
-                        `${scheduled.getHours()}:${String(
-                          scheduled.getMinutes()
-                        ).padStart(2, "0")}`
+                        (() => {
+                          const d = new Date(session.scheduled_at);
+                          return `${d.getHours()}:${String(d.getMinutes()).padStart(2, "0")}`;
+                        })()
                       )}
                     </p>
                   </div>
-                  <a
-                    href={session.meetingLink}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={(e) => e.stopPropagation()}
-                    className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium text-foreground bg-accent rounded-lg hover:bg-accent-hover transition-colors"
-                  >
-                    <Video className="w-3.5 h-3.5" />
-                    Join
-                  </a>
+                  {session.meeting_link && (
+                    <a
+                      href={session.meeting_link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={(e) => e.stopPropagation()}
+                      className="flex items-center gap-1.5 px-3 py-1.5 text-[13px] font-medium text-foreground bg-accent rounded-lg hover:bg-accent-hover transition-colors"
+                    >
+                      <Video className="w-3.5 h-3.5" />
+                      Join
+                    </a>
+                  )}
                 </Link>
               );
             })}
@@ -81,9 +105,7 @@ export default function DashboardPage() {
           className="flex items-center justify-between p-5 rounded-xl border border-border bg-card hover:bg-card-hover transition-colors group"
         >
           <div>
-            <p className="text-[15px] font-semibold mb-1">
-              {interviewerCount} interviewer{interviewerCount !== 1 ? "s" : ""} available
-            </p>
+            <p className="text-[15px] font-semibold mb-1">Find your next partner</p>
             <p className="text-[13px] text-muted-foreground">
               Browse peers, pick a match, and book directly on their calendar.
             </p>

--- a/client/app/(app)/layout.tsx
+++ b/client/app/(app)/layout.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { Avatar } from "@/components/ui/avatar";
-import { currentUser, notifications } from "@/lib/mock-data";
+import { useAuth } from "@/lib/context/auth";
 import { cn } from "@/lib/utils";
 import { Bell } from "lucide-react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
-import { useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 
 const navItems = [
   { href: "/dashboard", label: "Home" },
@@ -16,8 +16,17 @@ const navItems = [
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
+  const router = useRouter();
+  const { user, loading } = useAuth();
   const [showNotifs, setShowNotifs] = useState(false);
-  const unreadCount = notifications.filter((n) => !n.read).length;
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.replace("/login");
+    }
+  }, [loading, user, router]);
+
+  if (loading || !user) return null;
 
   return (
     <div className="min-h-screen bg-background">
@@ -58,9 +67,6 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                 className="relative p-2 rounded-lg hover:bg-muted transition-colors cursor-pointer"
               >
                 <Bell className="w-4 h-4 text-muted-foreground" />
-                {unreadCount > 0 && (
-                  <span className="absolute top-1.5 right-1.5 w-1.5 h-1.5 bg-danger rounded-full" />
-                )}
               </button>
 
               {showNotifs && (
@@ -73,23 +79,8 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                     <div className="px-4 py-2.5 border-b border-border">
                       <p className="text-[13px] font-semibold">Notifications</p>
                     </div>
-                    <div className="max-h-64 overflow-y-auto">
-                      {notifications.map((n) => (
-                        <Link
-                          key={n.id}
-                          href={n.actionUrl || "#"}
-                          onClick={() => setShowNotifs(false)}
-                          className={cn(
-                            "block px-4 py-2.5 hover:bg-muted/50 transition-colors border-b border-border/50 last:border-0",
-                            !n.read && "bg-muted/50"
-                          )}
-                        >
-                          <p className="text-[13px] font-medium">{n.title}</p>
-                          <p className="text-[12px] text-muted-foreground">
-                            {n.message}
-                          </p>
-                        </Link>
-                      ))}
+                    <div className="px-4 py-4 text-[13px] text-muted-foreground">
+                      No notifications yet
                     </div>
                   </div>
                 </>
@@ -100,7 +91,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
               href="/profile"
               className="p-1 rounded-lg hover:bg-muted transition-colors"
             >
-              <Avatar name={currentUser.name} size="sm" />
+              <Avatar name={user.full_name} size="sm" />
             </Link>
           </div>
         </div>

--- a/client/app/layout.tsx
+++ b/client/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { AuthProvider } from "@/lib/context/auth";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -28,7 +29,7 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <AuthProvider>{children}</AuthProvider>
       </body>
     </html>
   );

--- a/client/app/login/page.tsx
+++ b/client/app/login/page.tsx
@@ -7,9 +7,11 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { authApi } from "@/lib/services/auth";
+import { useAuth } from "@/lib/context/auth";
 
 export default function LoginPage() {
   const router = useRouter();
+  const { setUser } = useAuth();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [loading, setLoading] = useState(false);
@@ -39,7 +41,8 @@ export default function LoginPage() {
             setError("");
             setLoading(true);
             try {
-              await authApi.login(email, password);
+              const { user } = await authApi.login(email, password);
+              setUser(user);
               router.push("/dashboard");
             } catch (err) {
               setError(err instanceof Error ? err.message : "Login failed");

--- a/client/lib/context/auth.tsx
+++ b/client/lib/context/auth.tsx
@@ -6,6 +6,7 @@ import { authApi, type AuthUser } from "@/lib/services/auth";
 type AuthContextType = {
   user: AuthUser | null;
   loading: boolean;
+  setUser: (user: AuthUser | null) => void;
   logout: () => Promise<void>;
 };
 
@@ -31,7 +32,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <AuthContext.Provider value={{ user, loading, logout }}>
+    <AuthContext.Provider value={{ user, loading, setUser, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/client/lib/context/auth.tsx
+++ b/client/lib/context/auth.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+import { authApi, type AuthUser } from "@/lib/services/auth";
+
+type AuthContextType = {
+  user: AuthUser | null;
+  loading: boolean;
+  logout: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthContextType | null>(null);
+
+const BASE = process.env.NEXT_PUBLIC_API_URL!;
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch(`${BASE}/auth/me`, { credentials: "include" })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => setUser(data?.user ?? null))
+      .catch(() => setUser(null))
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function logout() {
+    await authApi.logout();
+    setUser(null);
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, loading, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error("useAuth must be used within AuthProvider");
+  return ctx;
+}

--- a/server/src/routes/auth.py
+++ b/server/src/routes/auth.py
@@ -1,6 +1,8 @@
-from flask import Blueprint, request, jsonify, make_response, current_app
+from flask import Blueprint, request, jsonify, make_response, current_app, g
 
 from src.services.auth_service import signup, login, logout, refresh
+from src.middleware.auth import require_auth
+from src.db import get_db
 
 auth_bp = Blueprint("auth", __name__)
 
@@ -114,3 +116,17 @@ def refresh_route():
     response = make_response(jsonify({"message": "Tokens refreshed"}))
     _set_auth_cookies(response, result["access_token"], result["refresh_token"])
     return response
+
+
+@auth_bp.route("/me", methods=["GET"])
+@require_auth
+def me_route():
+    db = get_db()
+    cur = db.cursor()
+    cur.execute("SELECT * FROM users WHERE id = %s", (g.user.id,))
+    user_row = cur.fetchone()
+
+    if not user_row:
+        return jsonify({"error": "User profile not found"}), 404
+
+    return jsonify({"user": dict(user_row)})

--- a/server/src/routes/sessions.py
+++ b/server/src/routes/sessions.py
@@ -1,3 +1,13 @@
-from flask import Blueprint
+from flask import Blueprint, jsonify, g
+
+from src.middleware.auth import require_auth
+from src.services.session_service import get_upcoming_sessions
 
 sessions_bp = Blueprint("sessions", __name__)
+
+
+@sessions_bp.route("/", methods=["GET"])
+@require_auth
+def list_sessions():
+    sessions = get_upcoming_sessions(g.user.id)
+    return jsonify([dict(s) for s in sessions])

--- a/server/src/services/session_service.py
+++ b/server/src/services/session_service.py
@@ -1,6 +1,39 @@
 from src.db import get_db
 
 
+def get_upcoming_sessions(user_id: str):
+    db = get_db()
+    cur = db.cursor()
+
+    cur.execute(
+        """
+        SELECT
+            s.id,
+            s.status,
+            s.scheduled_at,
+            s.meeting_link,
+            it.name AS interview_type,
+            interviewer.id   AS interviewer_id,
+            interviewer.full_name AS interviewer_name,
+            interviewer.email     AS interviewer_email,
+            interviewee.id   AS interviewee_id,
+            interviewee.full_name AS interviewee_name,
+            interviewee.email     AS interviewee_email
+        FROM sessions s
+        JOIN users interviewer ON interviewer.id = s.interviewer_id
+        JOIN users interviewee ON interviewee.id = s.interviewee_id
+        LEFT JOIN interview_types it ON it.id = s.interview_type_id
+        WHERE (s.interviewer_id = %s OR s.interviewee_id = %s)
+          AND s.status = 'confirmed'
+          AND s.scheduled_at > NOW()
+        ORDER BY s.scheduled_at ASC
+        """,
+        (user_id, user_id),
+    )
+
+    return cur.fetchall()
+
+
 def _get_user_id_by_email(cur, email: str):
     cur.execute("SELECT id FROM users WHERE email = %s", (email,))
     row = cur.fetchone()


### PR DESCRIPTION
  - Added AuthProvider and useAuth context to manage session state via httponly cookies                                                                            
  - Wired GET /auth/me on app load to persist login across page refreshes
  - Dashboard now fetches real upcoming sessions from GET /sessions/ instead of mock data                                                                          
  - App layout redirects unauthenticated users to /login       
  
  
   Test plan                                                                                                                                                        
                  
  - Sign up with a new account — should land on dashboard                                                                                                          
  - Refresh the page — should stay logged in
  - Visit /dashboard while logged out — should redirect to /login                                                                                                  
  - Log out — should clear cookies and redirect to /login                                                                                                          
  - Insert a session row in Supabase SQL Editor with your user ID and scheduled_at in the future, confirm it appears on the dashboard                              
  - Check network tab — GET /sessions/ returns 200 with session data                                                                      