### PR TITLE
feat: add public profile page with browse and dashboard links

### DIFF
--- a/client/app/(app)/browse/page.tsx
+++ b/client/app/(app)/browse/page.tsx
@@ -4,6 +4,7 @@ import { Avatar } from "@/components/ui/avatar";
 import { profilesApi, type ProfileUser } from "@/lib/services/profiles";
 import { cn, difficultyLabels, interviewTypeLabels } from "@/lib/utils";
 import { ExternalLink, Search, SlidersHorizontal, X } from "lucide-react";
+import Link from "next/link";
 import { useState, useRef, useEffect } from "react";
 
 const allExperiences = ["beginner", "intermediate", "advanced"];
@@ -214,10 +215,14 @@ export default function BrowsePage() {
         {peers.map((user) => (
           <div key={user.id} className="py-5 first:pt-0 last:pb-0">
             <div className="flex items-start gap-4">
-              <Avatar name={user.full_name} size="md" />
+              <Link href={`/profile/${user.id}`} className="shrink-0">
+                <Avatar name={user.full_name} size="md" />
+              </Link>
 
               <div className="flex-1 min-w-0">
-                <p className="text-[14px] font-medium mb-0.5">{user.full_name}</p>
+                <Link href={`/profile/${user.id}`} className="hover:underline underline-offset-2">
+                  <p className="text-[14px] font-medium mb-0.5">{user.full_name}</p>
+                </Link>
 
                 {user.bio && (
                   <p className="text-[13px] text-muted-foreground leading-relaxed mb-3 line-clamp-2">

--- a/client/app/(app)/dashboard/page.tsx
+++ b/client/app/(app)/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { get } from "@/lib/services/api";
 import { formatDate, formatTime, interviewTypeLabels } from "@/lib/utils";
 import { ArrowRight, Video } from "lucide-react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 
 type ApiSession = {
@@ -22,6 +23,7 @@ type ApiSession = {
 
 export default function DashboardPage() {
   const { user } = useAuth();
+  const router = useRouter();
   const [sessions, setSessions] = useState<ApiSession[]>([]);
   const [loading, setLoading] = useState(true);
 
@@ -55,16 +57,31 @@ export default function DashboardPage() {
               const partnerName = isInterviewer
                 ? session.interviewee_name
                 : session.interviewer_name;
+              const partnerId = isInterviewer
+                ? session.interviewee_id
+                : session.interviewer_id;
 
               return (
-                <Link
+                <div
                   key={session.id}
-                  href={`/sessions/${session.id}`}
-                  className="flex items-center gap-4 p-4 -mx-4 rounded-xl hover:bg-muted/50 transition-colors"
+                  onClick={() => router.push(`/sessions/${session.id}`)}
+                  className="flex items-center gap-4 p-4 -mx-4 rounded-xl hover:bg-muted/50 transition-colors cursor-pointer"
                 >
-                  <Avatar name={partnerName} size="md" />
+                  <Link
+                    href={`/profile/${partnerId}`}
+                    onClick={(e) => e.stopPropagation()}
+                    className="shrink-0"
+                  >
+                    <Avatar name={partnerName} size="md" />
+                  </Link>
                   <div className="flex-1 min-w-0">
-                    <p className="text-[14px] font-medium">{partnerName}</p>
+                    <Link
+                      href={`/profile/${partnerId}`}
+                      onClick={(e) => e.stopPropagation()}
+                      className="hover:underline underline-offset-2"
+                    >
+                      <p className="text-[14px] font-medium">{partnerName}</p>
+                    </Link>
                     <p className="text-[13px] text-muted-foreground">
                       {session.interview_type
                         ? interviewTypeLabels[session.interview_type] ?? session.interview_type
@@ -90,7 +107,7 @@ export default function DashboardPage() {
                       Join
                     </a>
                   )}
-                </Link>
+                </div>
               );
             })}
           </div>

--- a/client/app/(app)/profile/[userId]/page.tsx
+++ b/client/app/(app)/profile/[userId]/page.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { Avatar } from "@/components/ui/avatar";
+import { profileApi, type ProfileData } from "@/lib/services/profile";
+import { difficultyLabels, interviewTypeLabels } from "@/lib/utils";
+import { ExternalLink } from "lucide-react";
+import { useParams } from "next/navigation";
+import { useEffect, useState } from "react";
+
+const roleDisplay: Record<string, string> = {
+  interviewee: "I want to practice",
+  interviewer: "I can run interviews",
+  both: "Interviewer and Interviewee",
+};
+
+export default function PublicProfilePage() {
+  const { userId } = useParams<{ userId: string }>();
+  const [profile, setProfile] = useState<ProfileData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    profileApi
+      .getPublic(userId)
+      .then(setProfile)
+      .catch(() => setNotFound(true))
+      .finally(() => setLoading(false));
+  }, [userId]);
+
+  if (loading) {
+    return <p className="text-[14px] text-muted-foreground">Loading…</p>;
+  }
+
+  if (notFound || !profile) {
+    return <p className="text-[14px] text-destructive">Profile not found.</p>;
+  }
+
+  return (
+    <div>
+      {/* Profile header */}
+      <div className="flex items-start gap-5 mb-10">
+        <Avatar name={profile.full_name} size="xl" />
+        <div className="flex-1">
+          <h2 className="text-[18px] font-semibold">{profile.full_name}</h2>
+          {profile.timezone && (
+            <p className="text-[13px] text-muted-foreground mt-0.5">
+              {profile.timezone.split("/")[1]?.replace("_", " ") ?? profile.timezone}
+            </p>
+          )}
+          {profile.bio && (
+            <p className="text-[14px] text-muted-foreground leading-relaxed mt-2">
+              {profile.bio}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Preferences */}
+      <section className="mb-10">
+        <h2 className="text-[13px] font-medium text-muted-foreground uppercase tracking-wider mb-4">
+          Preferences
+        </h2>
+        <div className="space-y-4">
+          {profile.role && (
+            <div>
+              <p className="text-[12px] text-muted-foreground mb-1.5">Role</p>
+              <p className="text-[14px] font-medium">
+                {roleDisplay[profile.role] ?? profile.role}
+              </p>
+            </div>
+          )}
+          {profile.interview_types.length > 0 && (
+            <div>
+              <p className="text-[12px] text-muted-foreground mb-1.5">
+                Interview types
+              </p>
+              <div className="flex flex-wrap gap-1.5">
+                {profile.interview_types.map((t) => (
+                  <span
+                    key={t}
+                    className="px-2 py-0.5 text-[12px] bg-muted rounded-md font-medium capitalize"
+                  >
+                    {interviewTypeLabels[t] ?? t}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+          {profile.experience && (
+            <div>
+              <p className="text-[12px] text-muted-foreground mb-1.5">
+                Experience
+              </p>
+              <p className="text-[14px] font-medium">
+                {difficultyLabels[profile.experience] ?? profile.experience}
+              </p>
+            </div>
+          )}
+          {profile.topics.length > 0 && (
+            <div>
+              <p className="text-[12px] text-muted-foreground mb-1.5">Topics</p>
+              <div className="flex flex-wrap gap-1.5">
+                {profile.topics.map((t) => (
+                  <span
+                    key={t.id}
+                    className="px-2 py-0.5 text-[12px] bg-muted rounded-md"
+                  >
+                    {t.name}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+
+      {/* Target role */}
+      {profile.target_role && (
+        <section className="mb-10">
+          <h2 className="text-[13px] font-medium text-muted-foreground uppercase tracking-wider mb-4">
+            Relevant opportunities
+          </h2>
+          <p className="text-[14px]">{profile.target_role}</p>
+        </section>
+      )}
+
+      {/* Scheduling */}
+      {profile.cal_com_link && (
+        <section className="mb-10">
+          <h2 className="text-[13px] font-medium text-muted-foreground uppercase tracking-wider mb-4">
+            Scheduling
+          </h2>
+          <a
+            href={profile.cal_com_link}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 px-4 py-2 text-[13px] font-medium bg-accent hover:bg-accent-hover text-foreground rounded-lg transition-colors"
+          >
+            Schedule a session
+            <ExternalLink className="w-3.5 h-3.5" />
+          </a>
+        </section>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Creates a read-only public profile page at `/profile/[userId]` showing name, timezone, bio, role, interview types, experience, topics, target, role, and scheduling link
- Makes user avatars and names in Browse clickable, linking to the profile
- Makes partner avatars and names in Dashboard session rows clickable, linking to the profile (row click still navigates to the session)

## Test plan
- [ ] Click a user's avatar or name in Browse → lands on their public profile
- [ ] Click a partner's avatar or name in a Dashboard session row → lands on their profile
- [ ] Clicking elsewhere on a Dashboard session row still navigates to the session detail
- [ ] Public profile shows no edit button, no upcoming sessions, no sign-out
- [ ] "Schedule a session" button appears only when the user has a cal.com link
- [ ] Navigating to `/profile/<invalid-id>` shows "Profile not found."
- [ ] Schedule button in Browse still opens the external cal.com link correctly