### PR TITLE
fix: strip NULL from interview_types in profiles list

### DIFF
--- a/server/src/services/profile_service.py
+++ b/server/src/services/profile_service.py
@@ -33,7 +33,7 @@ def get_users(interview_type_id=None, timezone=None, experience=None):
             u.bio,
             u.cal_com_link,
             r.name AS role,
-            array_agg(DISTINCT it.name) AS interview_types
+            array_remove(array_agg(DISTINCT it.name), NULL) AS interview_types
         FROM users u
         LEFT JOIN roles r ON r.id = u.role_id
         LEFT JOIN user_interview_types uit ON uit.user_id = u.id


### PR DESCRIPTION
## Summary
- Browse page showed an empty filter pill under "Interview Type" and an empty badge on each user card for users with no interview types selected.
- Root cause: the `/profiles/` query used `array_agg(DISTINCT it.name)` over a `LEFT JOIN` on `user_interview_types`/`interview_types`. For users with no rows, Postgres produced `{NULL}` instead of `{}`, which the frontend rendered as an empty chip.
- Fix: wrap with `array_remove(..., NULL)` so the API returns `[]` for users without interview types.

## Test plan
- [ ] `GET /profiles/` returns `interview_types: []` (not `[null]`) for users with no interview types
- [ ] Browse page filter no longer shows the empty pill before Technical / Behavioral
- [ ] Browse page user cards no longer show the empty interview-type badge
- [ ] Users with interview types still render their pills correctly