### PR TITLE
fix(auth): use SameSite=None so cookies survive cross-origin reloads

### DIFF
--- a/server/src/routes/auth.py
+++ b/server/src/routes/auth.py
@@ -18,7 +18,7 @@ def _set_auth_cookies(response, access_token, refresh_token):
         access_token,
         httponly=True,
         secure=secure,
-        samesite="Lax",
+        samesite="None",
         path="/",
         max_age=current_app.config["JWT_ACCESS_TOKEN_EXPIRES"],
     )
@@ -27,7 +27,7 @@ def _set_auth_cookies(response, access_token, refresh_token):
         refresh_token,
         httponly=True,
         secure=secure,
-        samesite="Lax",
+        samesite="None",
         path="/",
         max_age=current_app.config["JWT_REFRESH_TOKEN_EXPIRES"],
     )


### PR DESCRIPTION
## Problem

Reloading the app kicks the user back to `/login` every time. `AuthProvider` mounts, calls `GET /auth/me`, and always gets 401 because the `access_token` cookie isn't sent on the reload fetch.

## Root cause

Auth cookies are set with `SameSite=Lax` (`server/src/routes/auth.py`). Whenever the client origin and the Flask API are on different sites, the browser blocks `Lax` cookies on cross-site subresource fetches.

This is our actual dev setup: Next dev server runs on `http://localhost:3000`, but `client/.env` points at `http://127.0.0.1:5000`. Browsers treat `localhost` and `127.0.0.1` as different sites, so every API call is cross-site. `POST /auth/login` still succeeds (the response sets the cookie), but on reload `GET /auth/me` never receives it → 401 → `setUser(null)` → redirect to `/login`.

The same class of bug hits any deployment where the API is on a different domain/subdomain than the client.

## Fix

Change the access and refresh cookies to `SameSite=None`. `Secure=True` is already being set, which is the pairing `SameSite=None` requires, and modern browsers accept `Secure` on `http://localhost`, so dev still works over HTTP.

## Test plan

- [ ] Log in, then hard-reload the dashboard — stays logged in instead of bouncing to `/login`.
- [ ] Log out — cookies cleared, `/auth/me` returns 401, redirect to `/login`.
- [ ] Signup flow still lands on the authenticated app shell.