### PR TITLE
fix: use cal_booking_uid for reschedule link

### DIFF
--- a/client/app/(app)/sessions/[id]/page.tsx
+++ b/client/app/(app)/sessions/[id]/page.tsx
@@ -240,10 +240,10 @@ export default function SessionDetailPage({
             </a>
           )}
 
-          {partnerCalComLink ? (
+          {session.cal_booking_uid ? (
             canReschedule ? (
               <a
-                href={partnerCalComLink}
+                href={`https://cal.com/reschedule/${session.cal_booking_uid}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="flex items-center gap-2 px-4 bg-muted rounded-xl hover:bg-border/60 transition-colors text-[14px] font-medium"

--- a/client/app/(app)/sessions/page.tsx
+++ b/client/app/(app)/sessions/page.tsx
@@ -11,10 +11,6 @@ import { useEffect, useState } from "react";
 
 const tabs = ["Upcoming", "Completed"];
 
-const canReschedule = (scheduledAt: string) => {
-  const oneHour = 1000 * 60 * 60;
-  return new Date(scheduledAt).getTime() - Date.now() > oneHour;
-};
 
 export default function SessionsPage() {
   const { user } = useAuth();
@@ -101,9 +97,6 @@ export default function SessionsPage() {
             const partnerName = isInterviewer
               ? session.interviewee_name
               : session.interviewer_name;
-            const partnerCalComLink = isInterviewer
-              ? session.interviewee_cal_com_link
-              : session.interviewer_cal_com_link;
             const scheduled = new Date(session.scheduled_at);
 
             return (
@@ -125,42 +118,17 @@ export default function SessionsPage() {
                     )}
                   </p>
                 </div>
-                {session.status === "confirmed" && (
-                  <div
-                    className="flex items-center gap-2"
-                    onClick={(e) => e.preventDefault()}
+                {session.status === "confirmed" && session.meeting_link && (
+                  <a
+                    href={session.meeting_link}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={(e) => e.stopPropagation()}
+                    className="text-[12px] font-medium text-foreground bg-accent px-2 py-1 rounded-md flex items-center gap-1"
                   >
-                    {session.meeting_link && (
-                      <a
-                        href={session.meeting_link}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-[12px] font-medium text-foreground bg-accent px-2 py-1 rounded-md flex items-center gap-1"
-                      >
-                        <Video className="w-3.5 h-3.5" />
-                        Join
-                      </a>
-                    )}
-                    {partnerCalComLink && (
-                      canReschedule(session.scheduled_at) ? (
-                        <a
-                          href={partnerCalComLink}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-[12px] font-medium text-muted-foreground border border-border px-2 py-1 rounded-md hover:text-foreground transition-colors"
-                        >
-                          Reschedule
-                        </a>
-                      ) : (
-                        <span
-                          title="Cannot reschedule within 1 hour of session"
-                          className="text-[12px] font-medium text-muted-foreground/40 border border-border px-2 py-1 rounded-md cursor-not-allowed"
-                        >
-                          Reschedule
-                        </span>
-                      )
-                    )}
-                  </div>
+                    <Video className="w-3.5 h-3.5" />
+                    Join
+                  </a>
                 )}
                 {session.status === "completed" && (
                   <span className="flex items-center gap-1 text-[12px] text-muted-foreground">

--- a/client/lib/services/sessions.ts
+++ b/client/lib/services/sessions.ts
@@ -18,6 +18,7 @@ export type ApiSession = {
   interviewee_timezone: string;
   interviewee_bio: string | null;
   interviewee_cal_com_link: string | null;
+  cal_booking_uid: string | null;
 };
 
 export type PersistedFeedback = {

--- a/server/src/services/session_service.py
+++ b/server/src/services/session_service.py
@@ -24,7 +24,8 @@ def _session_query(where_clause: str, params: tuple):
             interviewee.email        AS interviewee_email,
             interviewee.timezone     AS interviewee_timezone,
             interviewee.bio          AS interviewee_bio,
-            interviewee.cal_com_link AS interviewee_cal_com_link
+            interviewee.cal_com_link AS interviewee_cal_com_link,
+            s.cal_booking_uid
         FROM sessions s
         JOIN users interviewer ON interviewer.id = s.interviewer_id
         JOIN users interviewee ON interviewee.id = s.interviewee_id


### PR DESCRIPTION
Previously the Reschedule button linked to the partner's Cal.com profile, which would create a new booking instead of rescheduling the existing one. Now links to cal.com/reschedule/<uid> which opens the correct reschedule flow.