### PR TITLE
Fix Cal.com connected state persisting after page reload

### DIFF
--- a/client/app/(app)/profile/page.tsx
+++ b/client/app/(app)/profile/page.tsx
@@ -411,7 +411,7 @@ export default function ProfilePage() {
           Scheduling
         </h2>
 
-        {profile.cal_com_link?.includes("cal.com") || searchParams.get("cal") === "connected" ? (
+        {profile.cal_connected || searchParams.get("cal") === "connected" ? (
           <div className="space-y-3">
             <div className="flex items-center gap-2">
               <span className="text-[13px] text-success font-medium">✓ Cal.com connected</span>

--- a/client/lib/services/profile.ts
+++ b/client/lib/services/profile.ts
@@ -36,6 +36,7 @@ export type ProfileData = {
   bio: string;
   cal_com_link: string;
   cal_webhook_id: string | null;
+  cal_connected: boolean;
   role: UserRole;
   target_role: string;
   interview_types: string[];

--- a/server/src/services/profile_service.py
+++ b/server/src/services/profile_service.py
@@ -112,6 +112,8 @@ def get_me(user_id):
     )
     profile["topics"] = [{"id": r["id"], "name": r["name"]} for r in cur.fetchall()]
 
+    profile["cal_connected"] = bool(profile.get("cal_access_token"))
+
     cur.execute(
         """
         SELECT


### PR DESCRIPTION
Use cal_access_token presence as source of truth for whether Cal.com is connected, instead of cal_com_link containing "cal.com" which could be empty if get_cal_username returned None.