### PR TITLE
Save specific event type URL as cal_com_link instead of profile URL

### DIFF
--- a/server/src/routes/cal_oauth.py
+++ b/server/src/routes/cal_oauth.py
@@ -3,6 +3,7 @@ from flask import Blueprint, jsonify, redirect, request, g, current_app
 from src.middleware.auth import require_auth
 from src.services.cal_service import (
     exchange_code_for_tokens,
+    get_cal_booking_url,
     get_cal_username,
     get_oauth_authorize_url,
     register_webhook,
@@ -40,7 +41,7 @@ def exchange():
     except Exception:
         return jsonify({"error": "Could not fetch Cal.com username"}), 400
 
-    cal_com_link = f"https://cal.com/{username}" if username else ""
+    cal_com_link = get_cal_booking_url(access_token, username) if username else ""
 
     webhook_id = None
     try:

--- a/server/src/services/cal_service.py
+++ b/server/src/services/cal_service.py
@@ -53,6 +53,22 @@ def get_cal_username(access_token: str) -> Optional[str]:
     return resp.json().get("data", {}).get("username")
 
 
+def get_cal_booking_url(access_token: str, username: str) -> str:
+    """Return the first event type booking URL, falling back to the profile URL."""
+    try:
+        resp = requests.get(f"{CAL_API_BASE}/event-types", headers=_cal_headers(access_token))
+        resp.raise_for_status()
+        event_types = resp.json().get("data", {}).get("eventTypeGroups", [])
+        for group in event_types:
+            for et in group.get("eventTypes", []):
+                slug = et.get("slug")
+                if slug:
+                    return f"https://cal.com/{username}/{slug}"
+    except Exception:
+        pass
+    return f"https://cal.com/{username}"
+
+
 def register_webhook(access_token: str) -> Optional[str]:
     webhook_url = current_app.config["CAL_WEBHOOK_URL"]
     secret = current_app.config.get("CAL_WEBHOOK_SECRET", "")


### PR DESCRIPTION
Using the profile URL (cal.com/username) as the booking link caused metadata params to be lost when users navigated to a specific event type. Now fetches the first event type slug via the Cal.com API so metadata (intervieweeEmail, interviewType) is preserved on the booking page.